### PR TITLE
build: Warn about prebuilt apk in PRODUCT_COPY_FILES

### DIFF
--- a/core/Makefile
+++ b/core/Makefile
@@ -15,7 +15,7 @@ LOCAL_PATH := $(BUILD_SYSTEM)
 #$(2): the dest
 define check-product-copy-files
 $(if $(filter-out $(TARGET_COPY_OUT_SYSTEM_OTHER)/%,$(2)), \
-  $(if $(filter %.apk, $(2)),$(error \
+  $(if $(filter %.apk, $(2)),$(info \
      Prebuilt apk found in PRODUCT_COPY_FILES: $(1), use BUILD_PREBUILT instead!))) \
 $(if $(filter true,$(BUILD_BROKEN_VINTF_PRODUCT_COPY_FILES)),, \
   $(if $(filter $(TARGET_COPY_OUT_SYSTEM)/etc/vintf/% \


### PR DESCRIPTION
* Show a warning if an apk is found in PRODUCT_COPY_FILES

Change-Id: I4830c4f46b1ee33d916d015b6ed02d02ecf7faa3