### PR TITLE
releasetools: Add support for erofs

### DIFF
--- a/tools/releasetools/common.py
+++ b/tools/releasetools/common.py
@@ -3455,7 +3455,8 @@ PARTITION_TYPES = {
     "ext4": "EMMC",
     "emmc": "EMMC",
     "f2fs": "EMMC",
-    "squashfs": "EMMC"
+    "squashfs": "EMMC",
+    "erofs": "EMMC"
 }
 
 


### PR DESCRIPTION
Allow devices to add read-only filesystem to partitions that should not be modified.