### PR TITLE
Bump Security String to 2023-12-05

### DIFF
--- a/core/version_defaults.mk
+++ b/core/version_defaults.mk
@@ -103,7 +103,7 @@ ifndef PLATFORM_SECURITY_PATCH
     #  It must be of the form "YYYY-MM-DD" on production devices.
     #  It must match one of the Android Security Patch Level strings of the Public Security Bulletins.
     #  If there is no $PLATFORM_SECURITY_PATCH set, keep it empty.
-    PLATFORM_SECURITY_PATCH := 2023-11-05
+    PLATFORM_SECURITY_PATCH := 2023-12-05
 endif
 
 include $(BUILD_SYSTEM)/version_util.mk


### PR DESCRIPTION
Implemented:
============
CVE:            References:    Type:  Severity:  Updated AOSP versions:
CVE-2023-21267  A-218495634    ID     High       11, 12, 12L, 13, 14
CVE-2023-21394  A-296915211    ID     High       11, 12, 12L, 13
CVE-2023-35668  A-283962802    ID     High       11, 12, 12L, 13
CVE-2023-40073  A-287640400    ID     High       11, 12, 12L, 13, 14
CVE-2023-40074  A-247513680    DoS    High       11, 12, 12L, 13
CVE-2023-40075  A-281061287    DoS    High       11, 12, 12L, 13, 14
CVE-2023-40077  A-298057702    EoP    Critical   11, 12, 12L, 13, 14
CVE-2023-40080  A-275057843    EoP    High       13, 14
CVE-2023-40081  A-284297452    ID     High       11, 12, 12L, 13, 14
CVE-2023-40083  A-277590580    ID     High       12, 12L, 13, 14
CVE-2023-40084  A-272382770    EoP    High       11, 12, 12L, 13, 14
CVE-2023-40087  A-275895309    EoP    High       11, 12, 12L, 13, 14
CVE-2023-40088  A-291500341    RCE    Critical   11, 12, 12L, 13, 14
CVE-2023-40090  A-274478807    EoP    High       11, 12, 12L, 13, 14
CVE-2023-40091  A-283699145    EoP    High       11, 12, 12L, 13, 14
CVE-2023-40092  A-288110451    ID     High       11, 12, 12L, 13, 14
CVE-2023-40094  A-288896339    EoP    High       11, 12, 12L, 13, 14
CVE-2023-40095  A-273729172    EoP    High       11, 12, 12L, 13, 14
CVE-2023-40096  A-268724205    EoP    High       11, 12, 12L, 13, 14
CVE-2023-40097  A-295334906    EoP    High       11, 12, 12L, 13
CVE-2023-40098  A-288896269    ID     High       12, 12L, 13, 14
CVE-2023-45773  A-275057847    EoP    High       13, 14
CVE-2023-45774  A-288113797    EoP    High       11, 12, 12L, 13, 14
CVE-2023-45777  A-299930871    EoP    High       13, 14
CVE-2023-45781  A-275553827    ID     High       12, 12L, 13, 14
CVE-2023-45866  A-294854926    EoP    Critical   11, 12, 12L, 13, 14

Previously Implemented:
=======================
None

Not Implemented:
=======================
None

Not Applicable (platform source):
=================================
CVE:            References:    Type:  Severity:  Updated AOSP versions:
CVE-2023-40076  A-303835719    ID     Critical   14
CVE-2023-40078  A-275626001    EoP    High       14
CVE-2023-40079  A-278722815    EoP    High       14
CVE-2023-40082  A-290909089    EoP    High       14
CVE-2023-40089  A-294228721    EoP    High       14
CVE-2023-40103  A-197260547    EoP    High       14
CVE-2023-45775  A-275340684    EoP    High       14
CVE-2023-45776  A-282234870    EoP    High       14