### PR TITLE
jemalloc by default(1/5) 

### DIFF
--- a/core/config_sanitizers.mk
+++ b/core/config_sanitizers.mk
@@ -299,7 +299,7 @@ ifneq ($(filter address thread hwaddress,$(my_sanitize)),)
 endif
 
 # Or if disabled globally.
-ifeq ($(PRODUCT_DISABLE_SCUDO),true)
+ifneq ($(PRODUCT_USE_SCUDO),true)
   my_sanitize := $(filter-out scudo,$(my_sanitize))
 endif
 

--- a/core/product.mk
+++ b/core/product.mk
@@ -260,8 +260,8 @@ _product_list_vars += PRODUCT_MEMTAG_HEAP_EXCLUDE_PATHS
 # Whether this product wants to start with an empty list of default memtag_heap include paths
 _product_single_value_vars += PRODUCT_MEMTAG_HEAP_SKIP_DEFAULT_PATHS
 
-# Whether the Scudo hardened allocator is disabled platform-wide
-_product_single_value_vars += PRODUCT_DISABLE_SCUDO
+# Whether the Scudo hardened allocator is enabled platform-wide
+_product_single_value_vars += PRODUCT_USE_SCUDO
 
 # List of extra VNDK versions to be included
 _product_list_vars += PRODUCT_EXTRA_VNDK_VERSIONS

--- a/core/soong_config.mk
+++ b/core/soong_config.mk
@@ -126,8 +126,6 @@ $(call add_json_list, MemtagHeapExcludePaths,            $(MEMTAG_HEAP_EXCLUDE_P
 $(call add_json_list, MemtagHeapAsyncIncludePaths,       $(MEMTAG_HEAP_ASYNC_INCLUDE_PATHS) $(PRODUCT_MEMTAG_HEAP_ASYNC_INCLUDE_PATHS) $(if $(filter true,$(PRODUCT_MEMTAG_HEAP_SKIP_DEFAULT_PATHS)),,$(PRODUCT_MEMTAG_HEAP_ASYNC_DEFAULT_INCLUDE_PATHS)))
 $(call add_json_list, MemtagHeapSyncIncludePaths,       $(MEMTAG_HEAP_SYNC_INCLUDE_PATHS) $(PRODUCT_MEMTAG_HEAP_SYNC_INCLUDE_PATHS) $(if $(filter true,$(PRODUCT_MEMTAG_HEAP_SKIP_DEFAULT_PATHS)),,$(PRODUCT_MEMTAG_HEAP_SYNC_DEFAULT_INCLUDE_PATHS)))
 
-$(call add_json_bool, DisableScudo,                      $(filter true,$(PRODUCT_DISABLE_SCUDO)))
-
 $(call add_json_bool, ClangTidy,                         $(filter 1 true,$(WITH_TIDY)))
 $(call add_json_str,  TidyChecks,                        $(WITH_TIDY_CHECKS))
 
@@ -154,6 +152,7 @@ $(call add_json_list, ExtraVndkVersions,                 $(PRODUCT_EXTRA_VNDK_VE
 $(call add_json_list, DeviceSystemSdkVersions,           $(BOARD_SYSTEMSDK_VERSIONS))
 $(call add_json_str,  RecoverySnapshotVersion,           $(RECOVERY_SNAPSHOT_VERSION))
 $(call add_json_list, Platform_systemsdk_versions,       $(PLATFORM_SYSTEMSDK_VERSIONS))
+$(call add_json_bool, Malloc_use_scudo,                  $(filter true,$(PRODUCT_USE_SCUDO)))
 $(call add_json_bool, Malloc_not_svelte,                 $(call invert_bool,$(filter true,$(MALLOC_SVELTE))))
 $(call add_json_bool, Malloc_zero_contents,              $(call invert_bool,$(filter false,$(MALLOC_ZERO_CONTENTS))))
 $(call add_json_bool, Malloc_pattern_fill_contents,      $(MALLOC_PATTERN_FILL_CONTENTS))

--- a/target/product/go_defaults_common.mk
+++ b/target/product/go_defaults_common.mk
@@ -41,11 +41,6 @@ PRODUCT_ART_TARGET_INCLUDE_DEBUG_BUILD := false
 # leave less information available via JDWP.
 PRODUCT_MINIMIZE_JAVA_DEBUG_INFO := true
 
-# Disable Scudo outside of eng builds to save RAM.
-ifneq (,$(filter eng, $(TARGET_BUILD_VARIANT)))
-  PRODUCT_DISABLE_SCUDO := true
-endif
-
 # Add the system properties.
 TARGET_SYSTEM_PROP += \
     build/make/target/board/go_defaults_common.prop


### PR DESCRIPTION
Jemalloc by default is good because of  : 

1. Reduced Fragmentation: jemalloc employs sophisticated algorithms to allocate memory in a way that minimizes fragmentation. This fragmentation occurs when freed memory becomes scattered in small chunks, making it difficult to allocate larger blocks efficiently. jemalloc's approach helps maintain contiguous memory regions, leading to faster allocation and deallocation operations.

2. jemalloc excels in multi-threaded environments. It utilizes thread-caching mechanisms and per-thread allocation arenas to minimize contention and improve memory access speed for concurrent threads.

3. jemalloc provides valuable debugging features that can aid in troubleshooting memory-related issues within the operating system. These tools can help pinpoint memory leaks, identify memory usage patterns, and diagnose allocation/deallocation problems, leading to a more stable and reliable system.

4. It also make's the device perform well at higer  load's and improve performance. 


You can check other PR regarding this from these Links.  

[Build_soong](https://github.com/DerpFest-AOSP/build_soong/pull/6) (2/5)
[Bionic](https://github.com/DerpFest-AOSP/bionic/pull/3) (3/5)
[external_jemalloc_new](https://github.com/DerpFest-AOSP/external_jemalloc_new/pull/1) (4/5)
[manifest](https://github.com/DerpFest-AOSP/manifest/pulls/21) (5/5)