### PR TITLE
Bump Security String to 2024-09-05

### DIFF
--- a/core/version_defaults.mk
+++ b/core/version_defaults.mk
@@ -103,7 +103,7 @@ ifndef PLATFORM_SECURITY_PATCH
     #  It must be of the form "YYYY-MM-DD" on production devices.
     #  It must match one of the Android Security Patch Level strings of the Public Security Bulletins.
     #  If there is no $PLATFORM_SECURITY_PATCH set, keep it empty.
-    PLATFORM_SECURITY_PATCH := 2024-08-05
+    PLATFORM_SECURITY_PATCH := 2024-09-05
 endif
 
 include $(BUILD_SYSTEM)/version_util.mk


### PR DESCRIPTION
Implemented:
============
CVE:            References:    Type:  Severity:  Updated AOSP versions:
CVE-2024-32896  A-324321147    EoP    High       12, 12L, 13, 14
CVE-2024-40650  A-293199910    EoP    High       12, 12L, 13, 14
CVE-2024-40652  A-327749022    EoP    High       12, 12L, 13, 14
CVE-2024-40654  A-333364513    EoP    High       12, 12L, 13, 14
CVE-2024-40655  A-300904123    EoP    High       12, 12L, 13, 14
CVE-2024-40656  A-329058967    ID     High       12, 12L, 13, 14
CVE-2024-40657  A-341886134    EoP    High       12, 12L, 13, 14
CVE-2024-40658  A-329641908    EoP    High       12, 12L, 13, 14
CVE-2024-40662  A-261721900    EoP    High       12, 12L, 13, 14

Not Implemented:
================
None

Not Applicable (platform source):
=================================
CVE:            References:    Type:  Severity:  Updated AOSP versions:
CVE-2024-40659  A-336976105    DoS    High       14

Change-Id: I409ea654cebe1d607e4e89ffd1ca3ed1915b2ef0